### PR TITLE
Add bare minimum palette functionality and testing

### DIFF
--- a/Derpy.Tests/PaletteTest.cs
+++ b/Derpy.Tests/PaletteTest.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using Moq.Protected;
+using Xunit;
+
+namespace Derpy.Tests
+{
+    public class PaletteTest
+    {
+        private readonly Palette.Service _palette;
+        private readonly Mock<HttpMessageHandler> _handler = new Mock<HttpMessageHandler>();
+
+        public PaletteTest()
+        {
+            _palette = new Palette.Service(_handler.Object);
+        }
+
+        [Fact]
+        public async void Test_GetRandomColourPaletteUrl()
+        {
+            _handler.Protected()
+                .Setup<Task<HttpResponseMessage>>("SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    RequestMessage = new HttpRequestMessage
+                    {
+                        RequestUri = new Uri("https://www.example.com/new-url")
+                    }
+                });
+
+            var url = await _palette.GetRandomColourPaletteUrl();
+            Assert.Equal("https://www.example.com/new-url", url);
+        }
+
+        [Fact]
+        public async void Test_GetRandomColourPaletteUrlBad()
+        {
+            _handler.Protected()
+                .Setup<Task<HttpResponseMessage>>("SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.BadRequest
+                });
+
+            var url = await _palette.GetRandomColourPaletteUrl();
+            Assert.Null(url);
+        }
+    }
+}

--- a/Derpy/Palette/Commands.cs
+++ b/Derpy/Palette/Commands.cs
@@ -1,0 +1,21 @@
+using System.Threading.Tasks;
+using Derpy.Result;
+using Discord.Commands;
+
+namespace Derpy.Palette
+{
+    public class Commands : ModuleBase<SocketCommandContext>
+    {
+        private readonly Service _service;
+
+        public Commands(Service service)
+        {
+            _service = service;
+        }
+
+        [Command("palette")]
+        [Summary("Returns a random palette")]
+        public async Task<RuntimeResult> Palette()
+            => new DiscordResult(await _service.ShowPalette());
+    }
+}

--- a/Derpy/Palette/Service.cs
+++ b/Derpy/Palette/Service.cs
@@ -1,0 +1,34 @@
+using System.Net.Http;
+using System.Threading.Tasks;
+using Derpy.Result;
+
+namespace Derpy.Palette
+{
+    public class Service
+    {
+        public const string RANDOM_COLOUR_PALETTE_URL = "https://www.colourpod.com/random";
+        private readonly HttpClient _httpClient;
+
+        public Service(HttpMessageHandler handler)
+        {
+            _httpClient = new HttpClient(handler);
+        }
+
+        public async Task<IResult> ShowPalette()
+        {
+            var url = await GetRandomColourPaletteUrl();
+            if (string.IsNullOrEmpty(url))
+            {
+                return new Reply("I couldn't get a random palette for you", false);
+            }
+
+            return new Reply($"Here's a random palette for you to try! {url}");
+        }
+
+        public async Task<string> GetRandomColourPaletteUrl()
+        {
+            var res = await _httpClient.GetAsync(RANDOM_COLOUR_PALETTE_URL);
+            return res.IsSuccessStatusCode ? res.RequestMessage.RequestUri.AbsoluteUri : null;
+        }
+    }
+}

--- a/Derpy/Program.cs
+++ b/Derpy/Program.cs
@@ -7,7 +7,9 @@ using Sentry;
 using Serilog;
 using StackExchange.Redis;
 using System;
+using System.Net.Http;
 using System.Reflection;
+using System.Security.Authentication;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -68,6 +70,11 @@ namespace Derpy
                 .AddSingleton<Roles.Service>()
                 .AddSingleton<Tips.Service>()
                 .AddSingleton<Prompt.Service>()
+                .AddSingleton<Palette.Service>()
+                .AddSingleton<HttpMessageHandler>(new HttpClientHandler
+                {
+                    SslProtocols = SslProtocols.Tls12
+                })
                 .BuildServiceProvider();
         }
 


### PR DESCRIPTION
The command %palette may now give users a randomly selected palette from
colourpod.com, but there is as of yet no extra functionality around the
types of palettes users may choose, as was the case with Princess Luna.

This was implemented by doing a GET on the /random endpoint on the
Tumblr blog, which will fetch a random post and overwrite the request
message with that post's URL. This is a bit of a hack, however, as a
better solution would allow users to specify associated tags for some
palettes, as per original functionality.