### PR TITLE
Palette commands - full implementation

### DIFF
--- a/Derpy.Tests/Derpy.Tests.csproj
+++ b/Derpy.Tests/Derpy.Tests.csproj
@@ -7,6 +7,14 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Remove="Utils\TestResponses\full.json" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="Utils\TestResponses\full.json" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="Norn.Test" Version="0.1.4" />

--- a/Derpy.Tests/Derpy.Tests.csproj
+++ b/Derpy.Tests/Derpy.Tests.csproj
@@ -7,11 +7,15 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Remove="Utils\TestResponses\bad.json" />
     <None Remove="Utils\TestResponses\full.json" />
+    <None Remove="Utils\TestResponses\malformed.json" />
   </ItemGroup>
 
   <ItemGroup>
+    <EmbeddedResource Include="Utils\TestResponses\bad.json" />
     <EmbeddedResource Include="Utils\TestResponses\full.json" />
+    <EmbeddedResource Include="Utils\TestResponses\malformed.json" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Derpy.Tests/PaletteTest.cs
+++ b/Derpy.Tests/PaletteTest.cs
@@ -1,10 +1,6 @@
-using System;
-using System.Net;
-using System.Net.Http;
-using System.Threading;
 using System.Threading.Tasks;
+using Derpy.Utils.Tumblr;
 using Moq;
-using Moq.Protected;
 using Xunit;
 
 namespace Derpy.Tests
@@ -12,26 +8,20 @@ namespace Derpy.Tests
     public class PaletteTest
     {
         private readonly Palette.Service _palette;
-        private readonly Mock<HttpMessageHandler> _handler = new Mock<HttpMessageHandler>();
+        private readonly Mock<ITumblrClient> _client = new Mock<ITumblrClient>();
 
         public PaletteTest()
         {
-            _palette = new Palette.Service(_handler.Object);
+            _palette = new Palette.Service(_client.Object);
         }
 
         [Fact]
         public async void Test_GetRandomColourPaletteUrl()
         {
-            _handler.Protected()
-                .Setup<Task<HttpResponseMessage>>("SendAsync",
-                    ItExpr.IsAny<HttpRequestMessage>(),
-                    ItExpr.IsAny<CancellationToken>())
-                .ReturnsAsync(new HttpResponseMessage
+            _client.Setup(client => client.GetAllPostUrlsAsync(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(new []
                 {
-                    RequestMessage = new HttpRequestMessage
-                    {
-                        RequestUri = new Uri("https://www.example.com/new-url")
-                    }
+                    "https://www.example.com/new-url"
                 });
 
             var url = await _palette.GetRandomColourPaletteUrl();
@@ -41,14 +31,8 @@ namespace Derpy.Tests
         [Fact]
         public async void Test_GetRandomColourPaletteUrlBad()
         {
-            _handler.Protected()
-                .Setup<Task<HttpResponseMessage>>("SendAsync",
-                    ItExpr.IsAny<HttpRequestMessage>(),
-                    ItExpr.IsAny<CancellationToken>())
-                .ReturnsAsync(new HttpResponseMessage
-                {
-                    StatusCode = HttpStatusCode.BadRequest
-                });
+            _client.Setup(client => client.GetAllPostUrlsAsync(It.IsAny<string>(), It.IsAny<string>()))
+                .Returns(Task.FromResult<string[]>(null));
 
             var url = await _palette.GetRandomColourPaletteUrl();
             Assert.Null(url);

--- a/Derpy.Tests/PaletteTest.cs
+++ b/Derpy.Tests/PaletteTest.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using Moq.Protected;
+using Xunit;
+
+namespace Derpy.Tests
+{
+    public class PaletteTest
+    {
+        private readonly Palette.Service _palette;
+        private readonly Mock<HttpMessageHandler> _handler = new Mock<HttpMessageHandler>();
+
+        public PaletteTest()
+        {
+            _palette = new Palette.Service(_handler.Object);
+        }
+
+        [Fact]
+        public async void Test_GetRandomColourPaletteUrl()
+        {
+            _handler.Protected()
+                .Setup<Task<HttpResponseMessage>>("SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    RequestMessage = new HttpRequestMessage
+                    {
+                        RequestUri = new Uri("https://www.example.com/new-url")
+                    }
+                });
+
+            var url = await _palette.GetRandomColourPaletteUrl();
+            Assert.Equal("https://www.example.com/new-url", url);
+        }
+
+        [Fact]
+        public async void Test_GetRandomColourPaletteUrlBad()
+        {
+            _handler.Protected()
+                .Setup<Task<HttpResponseMessage>>("SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.BadRequest
+                });
+
+            var url = await _palette.GetRandomColourPaletteUrl();
+            Assert.Null(url);
+        }
+    }
+}

--- a/Derpy.Tests/Utils/SnakeCaseNamingPolicyTest.cs
+++ b/Derpy.Tests/Utils/SnakeCaseNamingPolicyTest.cs
@@ -1,0 +1,40 @@
+using Derpy.Utils.Tumblr;
+using Xunit;
+
+namespace Derpy.Tests.Utils
+{
+    public class SnakeCaseNamingPolicyTest
+    {
+        private readonly SnakeCaseNamingPolicy _namingPolicy;
+
+        public SnakeCaseNamingPolicyTest() => _namingPolicy = new SnakeCaseNamingPolicy();
+
+        [Fact]
+        public void Test_Standard()
+        {
+            var t = _namingPolicy.ConvertName("TestName");
+            Assert.Equal("test_name", t);
+        }
+
+        [Fact]
+        public void Test_Single()
+        {
+            var t = _namingPolicy.ConvertName("Test");
+            Assert.Equal("test", t);
+        }
+
+        [Fact]
+        public void Test_Multiple()
+        {
+            var t = _namingPolicy.ConvertName("TestLongerName");
+            Assert.Equal("test_longer_name", t);
+        }
+
+        [Fact]
+        public void Test_Consecutive()
+        {
+            var t = _namingPolicy.ConvertName("TestXMLParsing");
+            Assert.Equal("test_x_m_l_parsing", t);
+        }
+    }
+}

--- a/Derpy.Tests/Utils/TestResponses/bad.json
+++ b/Derpy.Tests/Utils/TestResponses/bad.json
@@ -1,0 +1,6 @@
+{
+    "meta": {
+        "status": 400,
+        "msg": "Bad Request"
+    }
+}

--- a/Derpy.Tests/Utils/TestResponses/full.json
+++ b/Derpy.Tests/Utils/TestResponses/full.json
@@ -1,0 +1,82 @@
+{
+    "meta": {
+        "status": 200,
+        "msg": "OK"
+    },
+    "response": {
+        "blog": {
+            "title": "Test Blog",
+            "posts": 3,
+            "name": "test",
+            "url": "https:\/\/test-blog.tumblr.com\/",
+            "updated": 1308953007,
+            "description": "<p>Description.</p>",
+            "ask": true,
+            "ask_anon": false,
+            "likes": 33
+        },
+        "posts": [
+            {
+                "blog_name": "test-blog",
+                "id": 3507845453,
+                "id_string": "3507845453",
+                "post_url": "https:\/\/test-blog.tumblr.com\/post\/3507845453",
+                "type": "text",
+                "date": "2011-02-25 20:27:00 GMT",
+                "timestamp": 1298665620,
+                "state": "published",
+                "format": "html",
+                "reblog_key": "b0baQtsl",
+                "tags": [
+                    "tumblrize",
+                    "milky dog",
+                    "mini comic"
+                ],
+                "note_count": 14,
+                "title": "Test Title",
+                "body": "<p>Test body text</p>"
+            },
+            {
+                "blog_name": "test-blog",
+                "id": 4534708483,
+                "id_string": "4534708483",
+                "post_url": "https:\/\/test-blog.tumblr.com\/post\/4534708483",
+                "type": "text",
+                "date": "2011-02-25 20:27:00 GMT",
+                "timestamp": 1298665620,
+                "state": "published",
+                "format": "html",
+                "reblog_key": "b0baQtsl",
+                "tags": [
+                    "tumblrize",
+                    "milky dog",
+                    "mini comic"
+                ],
+                "note_count": 20,
+                "title": "Test Title",
+                "body": "<p>Test body text</p>"
+            },
+            {
+                "blog_name": "test-blog",
+                "id": 8943561832,
+                "id_string": "8943561832",
+                "post_url": "https:\/\/test-blog.tumblr.com\/post\/8943561832",
+                "type": "text",
+                "date": "2011-02-25 20:27:00 GMT",
+                "timestamp": 1298665620,
+                "state": "published",
+                "format": "html",
+                "reblog_key": "b0baQtsl",
+                "tags": [
+                    "tumblrize",
+                    "milky dog",
+                    "mini comic"
+                ],
+                "note_count": 3,
+                "title": "Test Title",
+                "body": "<p>Test body text</p>"
+            }
+        ],
+        "total_posts": 3
+    }
+}

--- a/Derpy.Tests/Utils/TestResponses/malformed.json
+++ b/Derpy.Tests/Utils/TestResponses/malformed.json
@@ -1,0 +1,9 @@
+{
+    "meta": {
+        "status": 200,
+        "msg": "OK"
+    },
+    "response": {
+        "blog": {
+            "title": "Test Blog",
+            "posts": 3,

--- a/Derpy.Tests/Utils/TumblrClientTest.cs
+++ b/Derpy.Tests/Utils/TumblrClientTest.cs
@@ -1,0 +1,79 @@
+using System;
+using System.IO;
+using System.Linq.Expressions;
+using System.Net.Http;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Derpy.Utils.Tumblr;
+using Moq;
+using Moq.Protected;
+using Xunit;
+
+namespace Derpy.Tests.Utils
+{
+    public class TumblrClientTest
+    {
+        private readonly TumblrClient _client;
+        private readonly Mock<HttpMessageHandler> _handler = new Mock<HttpMessageHandler>();
+
+        public TumblrClientTest()
+        {
+            _client = new TumblrClient(_handler.Object);
+        }
+
+        [Fact]
+        public async void Test_FullResponse()
+        {
+            _handler.Protected()
+                .Setup<Task<HttpResponseMessage>>("SendAsync",
+                    TumblrRequestMessageFor("test-blog"),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    Content = new StreamContent(LoadJsonResponse("full"))
+                });
+
+            var urls = await _client.GetAllPostUrlsAsync("test-blog");
+
+            Assert.Equal(3, urls.Length);
+            Assert.Equal(@"https://test-blog.tumblr.com/post/3507845453", urls[0]);
+            Assert.Equal(@"https://test-blog.tumblr.com/post/4534708483", urls[1]);
+            Assert.Equal(@"https://test-blog.tumblr.com/post/8943561832", urls[2]);
+        }
+
+        [Fact]
+        public async void Test_FullResponseWithTag()
+        {
+            _handler.Protected()
+                .Setup<Task<HttpResponseMessage>>("SendAsync",
+                    TumblrRequestMessageFor("test-blog", "test-tag"),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    Content = new StreamContent(LoadJsonResponse("full"))
+                });
+
+            var urls = await _client.GetAllPostUrlsAsync("test-blog", "test-tag");
+
+            Assert.Equal(3, urls.Length);
+            Assert.Equal(@"https://test-blog.tumblr.com/post/3507845453", urls[0]);
+            Assert.Equal(@"https://test-blog.tumblr.com/post/4534708483", urls[1]);
+            Assert.Equal(@"https://test-blog.tumblr.com/post/8943561832", urls[2]);
+        }
+
+        private static Stream LoadJsonResponse(string responseName)
+        {
+            var assembly = Assembly.GetExecutingAssembly();
+            return assembly.GetManifestResourceStream($"Derpy.Tests.Utils.TestResponses.{responseName}.json");
+        }
+
+        private static Expression TumblrRequestMessageFor(string blogIdentifier, string tag = null)
+        {
+            // Create request message that checks if correct URL is created by GetAllPostUrlsAsync
+            return ItExpr.Is<HttpRequestMessage>(req
+                => req.RequestUri.AbsolutePath.Split('/', StringSplitOptions.None)[3] == blogIdentifier
+                   && (tag == null || req.RequestUri.Query.Contains($"tag={tag}")));
+        }
+    }
+}

--- a/Derpy.Tests/Utils/TumblrClientTest.cs
+++ b/Derpy.Tests/Utils/TumblrClientTest.cs
@@ -5,6 +5,7 @@ using System.Net.Http;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
+using Derpy.Utils;
 using Derpy.Utils.Tumblr;
 using Moq;
 using Moq.Protected;
@@ -19,7 +20,9 @@ namespace Derpy.Tests.Utils
 
         public TumblrClientTest()
         {
-            _client = new TumblrClient(_handler.Object);
+            var keyProvider = new Mock<IKeyProvider>();
+            keyProvider.Setup(key => key.TumblrApiKey).Returns("test-api-key");
+            _client = new TumblrClient(_handler.Object, keyProvider.Object);
         }
 
         [Fact]
@@ -72,7 +75,8 @@ namespace Derpy.Tests.Utils
         {
             // Create request message that checks if correct URL is created by GetAllPostUrlsAsync
             return ItExpr.Is<HttpRequestMessage>(req
-                => req.RequestUri.AbsolutePath.Split('/', StringSplitOptions.None)[3] == blogIdentifier
+                => req.RequestUri.Query.Contains("api_key=test-api-key")
+                   && req.RequestUri.AbsolutePath.Split('/', StringSplitOptions.None)[3] == blogIdentifier
                    && (tag == null || req.RequestUri.Query.Contains($"tag={tag}")));
         }
     }

--- a/Derpy.Tests/Utils/TumblrClientTest.cs
+++ b/Derpy.Tests/Utils/TumblrClientTest.cs
@@ -34,9 +34,9 @@ namespace Derpy.Tests.Utils
             var urls = await _client.GetAllPostUrlsAsync("test-blog");
 
             Assert.Equal(3, urls.Length);
-            Assert.Equal(@"https://test-blog.tumblr.com/post/3507845453", urls[0]);
-            Assert.Equal(@"https://test-blog.tumblr.com/post/4534708483", urls[1]);
-            Assert.Equal(@"https://test-blog.tumblr.com/post/8943561832", urls[2]);
+            Assert.Equal("https://test-blog.tumblr.com/post/3507845453", urls[0]);
+            Assert.Equal("https://test-blog.tumblr.com/post/4534708483", urls[1]);
+            Assert.Equal("https://test-blog.tumblr.com/post/8943561832", urls[2]);
         }
 
         [Fact]
@@ -51,9 +51,9 @@ namespace Derpy.Tests.Utils
             var urls = await _client.GetAllPostUrlsAsync("test-blog", "test-tag");
 
             Assert.Equal(3, urls.Length);
-            Assert.Equal(@"https://test-blog.tumblr.com/post/3507845453", urls[0]);
-            Assert.Equal(@"https://test-blog.tumblr.com/post/4534708483", urls[1]);
-            Assert.Equal(@"https://test-blog.tumblr.com/post/8943561832", urls[2]);
+            Assert.Equal("https://test-blog.tumblr.com/post/3507845453", urls[0]);
+            Assert.Equal("https://test-blog.tumblr.com/post/4534708483", urls[1]);
+            Assert.Equal("https://test-blog.tumblr.com/post/8943561832", urls[2]);
         }
 
         [Fact]

--- a/Derpy/Palette/Commands.cs
+++ b/Derpy/Palette/Commands.cs
@@ -1,0 +1,21 @@
+using System.Threading.Tasks;
+using Derpy.Result;
+using Discord.Commands;
+
+namespace Derpy.Palette
+{
+    public class Commands : ModuleBase<SocketCommandContext>
+    {
+        private readonly Service _service;
+
+        public Commands(Service service)
+        {
+            _service = service;
+        }
+
+        [Command("palette")]
+        [Summary("Returns a random palette")]
+        public async Task<RuntimeResult> Palette()
+            => new DiscordResult(await _service.ShowPalette());
+    }
+}

--- a/Derpy/Palette/Commands.cs
+++ b/Derpy/Palette/Commands.cs
@@ -72,6 +72,6 @@ namespace Derpy.Palette
         [Command("neutral")]
         [Summary("Returns a random neutral palette")]
         public async Task<RuntimeResult> GetNeutralPalette()
-            => new DiscordResult(await _service.ShowPalette("red"));
+            => new DiscordResult(await _service.ShowPalette("neutral"));
     }
 }

--- a/Derpy/Palette/Commands.cs
+++ b/Derpy/Palette/Commands.cs
@@ -4,6 +4,8 @@ using Discord.Commands;
 
 namespace Derpy.Palette
 {
+    [Group("palette")]
+    [Summary("Returns a random palette")]
     public class Commands : ModuleBase<SocketCommandContext>
     {
         private readonly Service _service;
@@ -13,9 +15,63 @@ namespace Derpy.Palette
             _service = service;
         }
 
-        [Command("palette")]
-        [Summary("Returns a random palette")]
-        public async Task<RuntimeResult> Palette()
+        [Command]
+        public async Task<RuntimeResult> GetPalette()
             => new DiscordResult(await _service.ShowPalette());
+
+        [Command("red")]
+        [Summary("Returns a random red palette")]
+        public async Task<RuntimeResult> GetRedPalette()
+            => new DiscordResult(await _service.ShowPalette("red"));
+
+        [Command("orange")]
+        [Summary("Returns a random orange palette")]
+        public async Task<RuntimeResult> GetOrangePalette()
+            => new DiscordResult(await _service.ShowPalette("orange"));
+
+        [Command("yellow")]
+        [Summary("Returns a random yellow palette")]
+        public async Task<RuntimeResult> GetYellowPalette()
+            => new DiscordResult(await _service.ShowPalette("yellow"));
+
+        [Command("green")]
+        [Summary("Returns a random green palette")]
+        public async Task<RuntimeResult> GetGreenPalette()
+            => new DiscordResult(await _service.ShowPalette("green"));
+
+        [Command("blue")]
+        [Summary("Returns a random blue palette")]
+        public async Task<RuntimeResult> GetBluePalette()
+            => new DiscordResult(await _service.ShowPalette("blue"));
+
+        [Command("violet")]
+        [Summary("Returns a random violet palette")]
+        public async Task<RuntimeResult> GetVioletPalette()
+            => new DiscordResult(await _service.ShowPalette("violet"));
+
+        [Command("mono")]
+        [Summary("Returns a random monochromatic palette")]
+        public async Task<RuntimeResult> GetMonoPalette()
+            => new DiscordResult(await _service.ShowPalette("mono"));
+
+        [Command("comp")]
+        [Summary("Returns a random complementary palette")]
+        public async Task<RuntimeResult> GetCompPalette()
+            => new DiscordResult(await _service.ShowPalette("comp"));
+
+        [Command("analog")]
+        [Summary("Returns a random analogous palette")]
+        public async Task<RuntimeResult> GetAnalogPalette()
+            => new DiscordResult(await _service.ShowPalette("analog"));
+
+        [Command("wc")]
+        [Summary("Returns a random warm+cool palette")]
+        public async Task<RuntimeResult> GetWcPalette()
+            => new DiscordResult(await _service.ShowPalette("wc"));
+
+        [Command("neutral")]
+        [Summary("Returns a random neutral palette")]
+        public async Task<RuntimeResult> GetNeutralPalette()
+            => new DiscordResult(await _service.ShowPalette("red"));
     }
 }

--- a/Derpy/Palette/Service.cs
+++ b/Derpy/Palette/Service.cs
@@ -44,7 +44,7 @@ namespace Derpy.Palette
 
         public async Task<string> GetRandomColourPaletteUrl(string paletteType = "")
         {
-            _paletteMap.TryGetValue(paletteType, out var paletteTag);
+            var paletteTag = _paletteMap.GetValueOrDefault(paletteType);
             var allPostUrls = await _httpClient.GetAllPostUrlsAsync(RANDOM_COLOUR_PALETTE_IDENTIFIER, paletteTag);
             return allPostUrls?.PickRandom();
         }

--- a/Derpy/Palette/Service.cs
+++ b/Derpy/Palette/Service.cs
@@ -1,0 +1,34 @@
+using System.Net.Http;
+using System.Threading.Tasks;
+using Derpy.Result;
+
+namespace Derpy.Palette
+{
+    public class Service
+    {
+        public const string RANDOM_COLOUR_PALETTE_URL = "https://www.colourpod.com/random";
+        private readonly HttpClient _httpClient;
+
+        public Service(HttpMessageHandler handler)
+        {
+            _httpClient = new HttpClient(handler);
+        }
+
+        public async Task<IResult> ShowPalette()
+        {
+            var url = await GetRandomColourPaletteUrl();
+            if (string.IsNullOrEmpty(url))
+            {
+                return new Reply("I couldn't get a random palette for you", false);
+            }
+
+            return new Reply($"Here's a random palette for you to try! {url}");
+        }
+
+        public async Task<string> GetRandomColourPaletteUrl()
+        {
+            var res = await _httpClient.GetAsync(RANDOM_COLOUR_PALETTE_URL);
+            return res.IsSuccessStatusCode ? res.RequestMessage.RequestUri.AbsoluteUri : null;
+        }
+    }
+}

--- a/Derpy/Program.cs
+++ b/Derpy/Program.cs
@@ -7,9 +7,7 @@ using Sentry;
 using Serilog;
 using StackExchange.Redis;
 using System;
-using System.Net.Http;
 using System.Reflection;
-using System.Security.Authentication;
 using System.Threading;
 using System.Threading.Tasks;
 using Derpy.Utils;
@@ -74,10 +72,7 @@ namespace Derpy
                 .AddSingleton<Tips.Service>()
                 .AddSingleton<Prompt.Service>()
                 .AddSingleton<Palette.Service>()
-                .AddSingleton<HttpMessageHandler>(new HttpClientHandler
-                {
-                    SslProtocols = SslProtocols.Tls12
-                })
+                .AddSingleton<IWebClient, WebClient>()
                 .AddSingleton<IKeyProvider, KeyProvider>()
                 .AddSingleton<ITumblrClient, TumblrClient>()
                 .BuildServiceProvider();

--- a/Derpy/Program.cs
+++ b/Derpy/Program.cs
@@ -13,6 +13,7 @@ using System.Security.Authentication;
 using System.Threading;
 using System.Threading.Tasks;
 using Derpy.Utils;
+using Derpy.Utils.Tumblr;
 
 namespace Derpy
 {
@@ -78,6 +79,7 @@ namespace Derpy
                     SslProtocols = SslProtocols.Tls12
                 })
                 .AddSingleton<IKeyProvider, KeyProvider>()
+                .AddSingleton<ITumblrClient, TumblrClient>()
                 .BuildServiceProvider();
         }
 

--- a/Derpy/Program.cs
+++ b/Derpy/Program.cs
@@ -12,6 +12,7 @@ using System.Reflection;
 using System.Security.Authentication;
 using System.Threading;
 using System.Threading.Tasks;
+using Derpy.Utils;
 
 namespace Derpy
 {
@@ -22,6 +23,7 @@ namespace Derpy
         private CancellationTokenSource _cancellationSource;
 
         private DiscordSocketClient Client => _services.GetRequiredService<DiscordSocketClient>();
+        private IKeyProvider KeyProvider => _services.GetRequiredService<IKeyProvider>();
 
         static async Task Main()
         {
@@ -75,6 +77,7 @@ namespace Derpy
                 {
                     SslProtocols = SslProtocols.Tls12
                 })
+                .AddSingleton<IKeyProvider, KeyProvider>()
                 .BuildServiceProvider();
         }
 
@@ -82,7 +85,7 @@ namespace Derpy
         {
             _cancellationSource = new CancellationTokenSource();
 
-            await Client.LoginAsync(TokenType.Bot, Environment.GetEnvironmentVariable("DISCORD_TOKEN"));
+            await Client.LoginAsync(TokenType.Bot, KeyProvider.DiscordToken);
             await Client.StartAsync();
 
             await Task.Delay(Timeout.Infinite, _cancellationSource.Token);

--- a/Derpy/Program.cs
+++ b/Derpy/Program.cs
@@ -7,7 +7,9 @@ using Sentry;
 using Serilog;
 using StackExchange.Redis;
 using System;
+using System.Net.Http;
 using System.Reflection;
+using System.Security.Authentication;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -68,6 +70,11 @@ namespace Derpy
                 .AddSingleton<Roles.Service>()
                 .AddSingleton<Tips.Service>()
                 .AddSingleton<Prompt.Service>()
+                .AddSingleton<Palette.Service>()
+                .AddSingleton<HttpMessageHandler>(new HttpClientHandler
+                {
+                    SslProtocols = SslProtocols.Tls12
+                })
                 .BuildServiceProvider();
         }
 

--- a/Derpy/Utils/IKeyProvider.cs
+++ b/Derpy/Utils/IKeyProvider.cs
@@ -1,0 +1,8 @@
+namespace Derpy.Utils
+{
+    public interface IKeyProvider
+    {
+        string DiscordToken { get; }
+        string TumblrApiKey { get; }
+    }
+}

--- a/Derpy/Utils/IWebClient.cs
+++ b/Derpy/Utils/IWebClient.cs
@@ -1,0 +1,11 @@
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace Derpy.Utils
+{
+    public interface IWebClient
+    {
+        Task<HttpResponseMessage> GetAsync(Uri requestUri);
+    }
+}

--- a/Derpy/Utils/KeyProvider.cs
+++ b/Derpy/Utils/KeyProvider.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace Derpy.Utils
+{
+    public class KeyProvider : IKeyProvider
+    {
+        public string DiscordToken => Environment.GetEnvironmentVariable("DISCORD_TOKEN");
+        public string TumblrApiKey => Environment.GetEnvironmentVariable("TUMBLR_API_KEY");
+    }
+}

--- a/Derpy/Utils/Tumblr/ITumblrClient.cs
+++ b/Derpy/Utils/Tumblr/ITumblrClient.cs
@@ -1,0 +1,9 @@
+using System.Threading.Tasks;
+
+namespace Derpy.Utils.Tumblr
+{
+    public interface ITumblrClient
+    {
+        Task<string[]> GetAllPostUrlsAsync(string blogIdentifier, string tag = null);
+    }
+}

--- a/Derpy/Utils/Tumblr/Model.cs
+++ b/Derpy/Utils/Tumblr/Model.cs
@@ -9,7 +9,7 @@ namespace Derpy.Utils.Tumblr
         public string PostUrl { get; set; }
     }
 
-    public class Response
+    public class PostResponse
     {
         public long TotalPosts { get; set; }
         public List<Post> Posts { get; set; }
@@ -21,9 +21,9 @@ namespace Derpy.Utils.Tumblr
         public string Msg { get; set; }
     }
 
-    public class PostsResponse
+    public class TumblrResponse
     {
         public Meta Meta { get; set; }
-        public Response Response { get; set; }
+        public PostResponse Response { get; set; }
     }
 }

--- a/Derpy/Utils/Tumblr/Model.cs
+++ b/Derpy/Utils/Tumblr/Model.cs
@@ -2,26 +2,26 @@ using System.Collections.Generic;
 
 namespace Derpy.Utils.Tumblr
 {
-    public class Post
+    public struct Post
     {
         public long Id { get; set; }
         public string BlogName { get; set; }
         public string PostUrl { get; set; }
     }
 
-    public class PostResponse
+    public struct PostResponse
     {
         public long TotalPosts { get; set; }
         public List<Post> Posts { get; set; }
     }
 
-    public class Meta
+    public struct Meta
     {
         public int Status { get; set; }
         public string Msg { get; set; }
     }
 
-    public class TumblrResponse
+    public struct TumblrResponse
     {
         public Meta Meta { get; set; }
         public PostResponse Response { get; set; }

--- a/Derpy/Utils/Tumblr/Model.cs
+++ b/Derpy/Utils/Tumblr/Model.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+
+namespace Derpy.Utils.Tumblr
+{
+    public class Post
+    {
+        public long Id { get; set; }
+        public string BlogName { get; set; }
+        public string PostUrl { get; set; }
+    }
+
+    public class Response
+    {
+        public long TotalPosts { get; set; }
+        public List<Post> Posts { get; set; }
+    }
+
+    public class Meta
+    {
+        public int Status { get; set; }
+        public string Msg { get; set; }
+    }
+
+    public class PostsResponse
+    {
+        public Meta Meta { get; set; }
+        public Response Response { get; set; }
+    }
+}

--- a/Derpy/Utils/Tumblr/SnakeCaseNamingPolicy.cs
+++ b/Derpy/Utils/Tumblr/SnakeCaseNamingPolicy.cs
@@ -1,0 +1,11 @@
+using System.Linq;
+using System.Text.Json;
+
+namespace Derpy.Utils.Tumblr
+{
+    public class SnakeCaseNamingPolicy : JsonNamingPolicy
+    {
+        public override string ConvertName(string name)
+            => string.Concat(name.Select((x, i) => i > 0 && char.IsUpper(x) ? "_" + x : x.ToString())).ToLower();
+    }
+}

--- a/Derpy/Utils/Tumblr/TumblrClient.cs
+++ b/Derpy/Utils/Tumblr/TumblrClient.cs
@@ -11,7 +11,7 @@ namespace Derpy.Utils.Tumblr
     public class TumblrClient
     {
         private static Uri apiUrl = new Uri("https://api.tumblr.com/v2/blog/");
-        private static string apiKey = "hello";
+        private readonly string _apiKey;
 
         private static JsonSerializerOptions _serializerOptions = new JsonSerializerOptions
         {
@@ -20,9 +20,10 @@ namespace Derpy.Utils.Tumblr
 
         private readonly HttpClient _httpClient;
 
-        public TumblrClient(HttpMessageHandler handler)
+        public TumblrClient(HttpMessageHandler handler, IKeyProvider keyProvider)
         {
             _httpClient = new HttpClient(handler);
+            _apiKey = keyProvider.TumblrApiKey;
         }
 
         // https://www.tumblr.com/docs/en/api/v2#posts--retrieve-published-posts
@@ -31,7 +32,7 @@ namespace Derpy.Utils.Tumblr
         {
             var @params = new Dictionary<string, string>
             {
-                { "api_key", apiKey }
+                { "api_key", _apiKey }
             };
 
             if (!string.IsNullOrWhiteSpace(tag))

--- a/Derpy/Utils/Tumblr/TumblrClient.cs
+++ b/Derpy/Utils/Tumblr/TumblrClient.cs
@@ -11,19 +11,18 @@ namespace Derpy.Utils.Tumblr
 {
     public class TumblrClient : ITumblrClient
     {
-        private static Uri apiUrl = new Uri("https://api.tumblr.com/v2/blog/");
+        private readonly IWebClient _webClient;
         private readonly string _apiKey;
 
+        private static Uri apiUrl = new Uri("https://api.tumblr.com/v2/blog/");
         private static JsonSerializerOptions _serializerOptions = new JsonSerializerOptions
         {
             PropertyNamingPolicy = new SnakeCaseNamingPolicy()
         };
 
-        private readonly HttpClient _httpClient;
-
-        public TumblrClient(HttpMessageHandler handler, IKeyProvider keyProvider)
+        public TumblrClient(IWebClient webClient, IKeyProvider keyProvider)
         {
-            _httpClient = new HttpClient(handler);
+            _webClient = webClient;
             _apiKey = keyProvider.TumblrApiKey;
         }
 
@@ -42,7 +41,7 @@ namespace Derpy.Utils.Tumblr
             }
 
             var uri = BuildUri(blogIdentifier, "/posts", @params);
-            var response = await _httpClient.GetAsync(uri);
+            var response = await _webClient.GetAsync(uri);
 
             if (!response.IsSuccessStatusCode)
             {

--- a/Derpy/Utils/Tumblr/TumblrClient.cs
+++ b/Derpy/Utils/Tumblr/TumblrClient.cs
@@ -48,7 +48,7 @@ namespace Derpy.Utils.Tumblr
                 return null;
             }
 
-            var responseData = await DeserializeResponse<PostsResponse>(response);
+            var responseData = await DeserializeResponse<TumblrResponse>(response);
 
             if (responseData.Meta.Status != 200)
             {

--- a/Derpy/Utils/Tumblr/TumblrClient.cs
+++ b/Derpy/Utils/Tumblr/TumblrClient.cs
@@ -9,7 +9,7 @@ using Serilog;
 
 namespace Derpy.Utils.Tumblr
 {
-    public class TumblrClient
+    public class TumblrClient : ITumblrClient
     {
         private static Uri apiUrl = new Uri("https://api.tumblr.com/v2/blog/");
         private readonly string _apiKey;

--- a/Derpy/Utils/Tumblr/TumblrClient.cs
+++ b/Derpy/Utils/Tumblr/TumblrClient.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace Derpy.Utils.Tumblr
+{
+    public class TumblrClient
+    {
+        private static Uri apiUrl = new Uri("https://api.tumblr.com/v2/blog/");
+        private static string apiKey = "hello";
+
+        private static JsonSerializerOptions _serializerOptions = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = new SnakeCaseNamingPolicy()
+        };
+
+        private readonly HttpClient _httpClient;
+
+        public TumblrClient(HttpMessageHandler handler)
+        {
+            _httpClient = new HttpClient(handler);
+        }
+
+        // https://www.tumblr.com/docs/en/api/v2#posts--retrieve-published-posts
+        // https://github.com/tumblr/docs/blob/master/api.md#posts--retrieve-published-posts
+        public async Task<string[]> GetAllPostUrlsAsync(string blogIdentifier, string tag = null)
+        {
+            var @params = new Dictionary<string, string>
+            {
+                { "api_key", apiKey }
+            };
+
+            if (!string.IsNullOrWhiteSpace(tag))
+            {
+                @params.Add("tag", tag);
+            }
+
+            var uri = BuildUri(blogIdentifier, "/posts", @params);
+            var response = await _httpClient.GetAsync(uri);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                // do logging i guess
+                return null;
+            }
+
+            var responseData = await DeserializeResponse<PostsResponse>(response);
+
+            if (responseData.Meta.Status != 200)
+            {
+                // do logging i guess
+                return null;
+            }
+
+            return responseData.Response.Posts.Select(post => post.PostUrl).ToArray();
+        }
+
+        private static async Task<T> DeserializeResponse<T>(HttpResponseMessage response)
+        {
+            try
+            {
+                var content = await response.Content.ReadAsStringAsync();
+                return JsonSerializer.Deserialize<T>(content, _serializerOptions);
+            }
+            catch (Exception)
+            {
+                // do logging i guess
+            }
+
+            return default;
+        }
+
+        private static Uri BuildUri(string blogIdentifier, string endpoint, Dictionary<string, string> @params = null)
+        {
+            var uriBuilder = new UriBuilder(apiUrl);
+            uriBuilder.Path += blogIdentifier + endpoint;
+
+            if (@params != null)
+            {
+                uriBuilder.Query = BuildQuery(@params);
+            }
+
+            return uriBuilder.Uri;
+        }
+
+        private static string BuildQuery(Dictionary<string, string> @params)
+        {
+            return string.Join("&", @params.Select(_ => $"{_.Key}={WebUtility.UrlEncode(_.Value)}"));
+        }
+    }
+}

--- a/Derpy/Utils/Tumblr/TumblrClient.cs
+++ b/Derpy/Utils/Tumblr/TumblrClient.cs
@@ -5,6 +5,8 @@ using System.Net;
 using System.Net.Http;
 using System.Text.Json;
 using System.Threading.Tasks;
+using Sentry;
+using Sentry.Protocol;
 using Serilog;
 
 namespace Derpy.Utils.Tumblr
@@ -46,6 +48,7 @@ namespace Derpy.Utils.Tumblr
             if (!response.IsSuccessStatusCode)
             {
                 Log.Error("Tumblr posts GET response returned {StatusCode}", response.StatusCode);
+                SentrySdk.CaptureMessage($"Tumblr posts GET response returned {response.StatusCode}", SentryLevel.Error);
                 return null;
             }
 
@@ -63,6 +66,7 @@ namespace Derpy.Utils.Tumblr
             if (responseData.Meta.Status != 200)
             {
                 Log.Error("Tumblr posts meta field returned {StatusCode}", responseData.Meta.Status);
+                SentrySdk.CaptureMessage($"Tumblr posts meta field returned {response.StatusCode}", SentryLevel.Error);
                 return null;
             }
 
@@ -80,6 +84,7 @@ namespace Derpy.Utils.Tumblr
             catch (Exception e)
             {
                 Log.Error(e, "Error when deserializing {content}", content);
+                SentrySdk.CaptureException(e);
                 throw;
             }
         }

--- a/Derpy/Utils/WebClient.cs
+++ b/Derpy/Utils/WebClient.cs
@@ -13,9 +13,6 @@ namespace Derpy.Utils
             _httpClient = new HttpClient();
         }
 
-        public async Task<HttpResponseMessage> GetAsync(Uri requestUri)
-        {
-           return await _httpClient.GetAsync(requestUri);
-        }
+        public Task<HttpResponseMessage> GetAsync(Uri requestUri) => _httpClient.GetAsync(requestUri);
     }
 }

--- a/Derpy/Utils/WebClient.cs
+++ b/Derpy/Utils/WebClient.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace Derpy.Utils
+{
+    public class WebClient : IWebClient
+    {
+        private readonly HttpClient _httpClient;
+
+        public WebClient()
+        {
+            _httpClient = new HttpClient();
+        }
+
+        public async Task<HttpResponseMessage> GetAsync(Uri requestUri)
+        {
+           return await _httpClient.GetAsync(requestUri);
+        }
+    }
+}


### PR DESCRIPTION
This PR should enable users to run the original selection of `!palette` commands as they appeared for the Princess Luna bot. It requires the use of the Tumblr 2.0 API to download all post URLs with a given tag in order to display palettes of different hues/compositions. As such, the bot will need to register a Tumblr API key and export it as an environment variable named `TUMBLR_API_KEY` (see KeyProvider class in `Utils/` for implementation).

This PR builds off work from the `palette-command` branch.

If using the Tumblr 2.0 API is undesired, this may be able to be rewritten to use the 1.0 API which does not require an API key but would require an extra HTTP call over the current implementation to return a random post URL. Another workaround may be to have a web scraper service that would build a local DB of post URLs and their tags, and have the bot query this instead.